### PR TITLE
organising packages - names and locations 

### DIFF
--- a/src/main/java/com/bit/joe/shoppingmall/controller/CategoryController.java
+++ b/src/main/java/com/bit/joe/shoppingmall/controller/CategoryController.java
@@ -11,8 +11,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.bit.joe.shoppingmall.dto.CategoryDto;
-import com.bit.joe.shoppingmall.response.Response;
+import com.bit.joe.shoppingmall.dto.response.Response;
+import com.bit.joe.shoppingmall.dto.shopDto.CategoryDto;
 import com.bit.joe.shoppingmall.service.CategoryService;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/bit/joe/shoppingmall/controller/ProductController.java
+++ b/src/main/java/com/bit/joe/shoppingmall/controller/ProductController.java
@@ -4,9 +4,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import com.bit.joe.shoppingmall.dto.request.ProductRequest;
+import com.bit.joe.shoppingmall.dto.response.Response;
 import com.bit.joe.shoppingmall.exception.InvalidCredentialsException;
-import com.bit.joe.shoppingmall.request.ProductRequest;
-import com.bit.joe.shoppingmall.response.Response;
 import com.bit.joe.shoppingmall.service.ProductService;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/bit/joe/shoppingmall/controller/UserController.java
+++ b/src/main/java/com/bit/joe/shoppingmall/controller/UserController.java
@@ -12,9 +12,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.bit.joe.shoppingmall.dto.UserDto;
+import com.bit.joe.shoppingmall.dto.response.Response;
+import com.bit.joe.shoppingmall.dto.shopDto.UserDto;
 import com.bit.joe.shoppingmall.enums.UserRole;
-import com.bit.joe.shoppingmall.response.Response;
 import com.bit.joe.shoppingmall.service.UserService;
 
 import jakarta.servlet.http.HttpSession;

--- a/src/main/java/com/bit/joe/shoppingmall/dto/request/ProductRequest.java
+++ b/src/main/java/com/bit/joe/shoppingmall/dto/request/ProductRequest.java
@@ -1,4 +1,4 @@
-package com.bit.joe.shoppingmall.request;
+package com.bit.joe.shoppingmall.dto.request;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/bit/joe/shoppingmall/dto/response/Response.java
+++ b/src/main/java/com/bit/joe/shoppingmall/dto/response/Response.java
@@ -1,11 +1,11 @@
-package com.bit.joe.shoppingmall.response;
+package com.bit.joe.shoppingmall.dto.response;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.bit.joe.shoppingmall.dto.CategoryDto;
-import com.bit.joe.shoppingmall.dto.ProductDto;
-import com.bit.joe.shoppingmall.dto.UserDto;
+import com.bit.joe.shoppingmall.dto.shopDto.CategoryDto;
+import com.bit.joe.shoppingmall.dto.shopDto.ProductDto;
+import com.bit.joe.shoppingmall.dto.shopDto.UserDto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import lombok.Builder;

--- a/src/main/java/com/bit/joe/shoppingmall/dto/shopDto/CategoryDto.java
+++ b/src/main/java/com/bit/joe/shoppingmall/dto/shopDto/CategoryDto.java
@@ -1,4 +1,4 @@
-package com.bit.joe.shoppingmall.dto;
+package com.bit.joe.shoppingmall.dto.shopDto;
 
 import java.util.List;
 

--- a/src/main/java/com/bit/joe/shoppingmall/dto/shopDto/ProductDto.java
+++ b/src/main/java/com/bit/joe/shoppingmall/dto/shopDto/ProductDto.java
@@ -1,4 +1,4 @@
-package com.bit.joe.shoppingmall.dto;
+package com.bit.joe.shoppingmall.dto.shopDto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/bit/joe/shoppingmall/dto/shopDto/UserDto.java
+++ b/src/main/java/com/bit/joe/shoppingmall/dto/shopDto/UserDto.java
@@ -1,4 +1,4 @@
-package com.bit.joe.shoppingmall.dto;
+package com.bit.joe.shoppingmall.dto.shopDto;
 
 import com.bit.joe.shoppingmall.enums.UserGender;
 import com.bit.joe.shoppingmall.enums.UserRole;

--- a/src/main/java/com/bit/joe/shoppingmall/mapper/CategoryMapper.java
+++ b/src/main/java/com/bit/joe/shoppingmall/mapper/CategoryMapper.java
@@ -2,7 +2,7 @@ package com.bit.joe.shoppingmall.mapper;
 
 import org.springframework.stereotype.Component;
 
-import com.bit.joe.shoppingmall.dto.CategoryDto;
+import com.bit.joe.shoppingmall.dto.shopDto.CategoryDto;
 import com.bit.joe.shoppingmall.entity.Category;
 
 @Component

--- a/src/main/java/com/bit/joe/shoppingmall/mapper/ProductMapper.java
+++ b/src/main/java/com/bit/joe/shoppingmall/mapper/ProductMapper.java
@@ -2,7 +2,7 @@ package com.bit.joe.shoppingmall.mapper;
 
 import org.springframework.stereotype.Component;
 
-import com.bit.joe.shoppingmall.dto.ProductDto;
+import com.bit.joe.shoppingmall.dto.shopDto.ProductDto;
 import com.bit.joe.shoppingmall.entity.Product;
 
 @Component

--- a/src/main/java/com/bit/joe/shoppingmall/mapper/UserMapper.java
+++ b/src/main/java/com/bit/joe/shoppingmall/mapper/UserMapper.java
@@ -2,7 +2,7 @@ package com.bit.joe.shoppingmall.mapper;
 
 import org.springframework.stereotype.Component;
 
-import com.bit.joe.shoppingmall.dto.UserDto;
+import com.bit.joe.shoppingmall.dto.shopDto.UserDto;
 import com.bit.joe.shoppingmall.entity.User;
 
 @Component

--- a/src/main/java/com/bit/joe/shoppingmall/service/CategoryService.java
+++ b/src/main/java/com/bit/joe/shoppingmall/service/CategoryService.java
@@ -1,7 +1,7 @@
 package com.bit.joe.shoppingmall.service;
 
-import com.bit.joe.shoppingmall.dto.CategoryDto;
-import com.bit.joe.shoppingmall.response.Response;
+import com.bit.joe.shoppingmall.dto.response.Response;
+import com.bit.joe.shoppingmall.dto.shopDto.CategoryDto;
 
 public interface CategoryService {
     Response createCategory(CategoryDto categoryRequest);

--- a/src/main/java/com/bit/joe/shoppingmall/service/Impl/CategoryServiceImpl.java
+++ b/src/main/java/com/bit/joe/shoppingmall/service/Impl/CategoryServiceImpl.java
@@ -5,12 +5,12 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
-import com.bit.joe.shoppingmall.dto.CategoryDto;
+import com.bit.joe.shoppingmall.dto.response.Response;
+import com.bit.joe.shoppingmall.dto.shopDto.CategoryDto;
 import com.bit.joe.shoppingmall.entity.Category;
 import com.bit.joe.shoppingmall.exception.NotFoundException;
 import com.bit.joe.shoppingmall.mapper.CategoryMapper;
 import com.bit.joe.shoppingmall.repository.CategoryRepository;
-import com.bit.joe.shoppingmall.response.Response;
 import com.bit.joe.shoppingmall.service.CategoryService;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/bit/joe/shoppingmall/service/Impl/ProductServiceImpl.java
+++ b/src/main/java/com/bit/joe/shoppingmall/service/Impl/ProductServiceImpl.java
@@ -6,14 +6,14 @@ import java.util.stream.Collectors;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import com.bit.joe.shoppingmall.dto.ProductDto;
+import com.bit.joe.shoppingmall.dto.response.Response;
+import com.bit.joe.shoppingmall.dto.shopDto.ProductDto;
 import com.bit.joe.shoppingmall.entity.Category;
 import com.bit.joe.shoppingmall.entity.Product;
 import com.bit.joe.shoppingmall.exception.NotFoundException;
 import com.bit.joe.shoppingmall.mapper.ProductMapper;
 import com.bit.joe.shoppingmall.repository.CategoryRepository;
 import com.bit.joe.shoppingmall.repository.ProductRepository;
-import com.bit.joe.shoppingmall.response.Response;
 import com.bit.joe.shoppingmall.service.ProductService;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/bit/joe/shoppingmall/service/Impl/UserServiceImpl.java
+++ b/src/main/java/com/bit/joe/shoppingmall/service/Impl/UserServiceImpl.java
@@ -5,12 +5,12 @@ import java.util.List;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import com.bit.joe.shoppingmall.dto.UserDto;
+import com.bit.joe.shoppingmall.dto.response.Response;
+import com.bit.joe.shoppingmall.dto.shopDto.UserDto;
 import com.bit.joe.shoppingmall.entity.User;
 import com.bit.joe.shoppingmall.exception.NotFoundException;
 import com.bit.joe.shoppingmall.mapper.UserMapper;
 import com.bit.joe.shoppingmall.repository.UserRepository;
-import com.bit.joe.shoppingmall.response.Response;
 import com.bit.joe.shoppingmall.service.UserService;
 
 import jakarta.servlet.http.HttpSession;

--- a/src/main/java/com/bit/joe/shoppingmall/service/ProductService.java
+++ b/src/main/java/com/bit/joe/shoppingmall/service/ProductService.java
@@ -1,6 +1,6 @@
 package com.bit.joe.shoppingmall.service;
 
-import com.bit.joe.shoppingmall.response.Response;
+import com.bit.joe.shoppingmall.dto.response.Response;
 
 public interface ProductService {
 

--- a/src/main/java/com/bit/joe/shoppingmall/service/UserService.java
+++ b/src/main/java/com/bit/joe/shoppingmall/service/UserService.java
@@ -1,7 +1,7 @@
 package com.bit.joe.shoppingmall.service;
 
-import com.bit.joe.shoppingmall.dto.UserDto;
-import com.bit.joe.shoppingmall.response.Response;
+import com.bit.joe.shoppingmall.dto.response.Response;
+import com.bit.joe.shoppingmall.dto.shopDto.UserDto;
 
 import jakarta.servlet.http.HttpSession;
 


### PR DESCRIPTION
packages organising

# 설명

- response 와 request packages가 packages 개수를 2개나 더 늘려버린 불편 이슈.
- 아래와 같이 변경 하였음.
- dto:
	- request, response, shopDto

## 변경 타입
- N/A

## 테스트 방법
- N/A

## Checklist:

- [x] 코드 스타일 ./gradlew spotlessApply 를 적용하였습니다.
- [x] 올리기 전에 코드 리뷰 작업을 하였습니다.
- [ ] 어려운 부분에 대해 주석을 추가했습니다
- [ ] 문서에 해당 변경 사항을 반영했습니다
- [x] 변경 사항으로 인한 치명적인 경고가 없습니다
