### PR TITLE
feat: /api/order/change-status

### DIFF
--- a/src/main/java/com/bit/joe/shoppingmall/controller/OrderController.java
+++ b/src/main/java/com/bit/joe/shoppingmall/controller/OrderController.java
@@ -31,4 +31,14 @@ public class OrderController {
     public ResponseEntity<Response> changeStatus(@RequestBody OrderRequest orderRequest) {
         return ResponseEntity.ok(orderService.changeOrderStatus(orderRequest));
     }
+
+    @GetMapping("/request-cancel")
+    public ResponseEntity<Response> requestCancel(@RequestBody OrderRequest orderRequest) {
+        return ResponseEntity.ok(orderService.requestCancel(orderRequest));
+    }
+
+    @GetMapping("/confirm-cancel")
+    public ResponseEntity<Response> confirmCancel(@RequestBody OrderRequest orderRequest) {
+        return ResponseEntity.ok(orderService.confirmCancel(orderRequest));
+    }
 }

--- a/src/main/java/com/bit/joe/shoppingmall/controller/OrderController.java
+++ b/src/main/java/com/bit/joe/shoppingmall/controller/OrderController.java
@@ -1,6 +1,7 @@
 package com.bit.joe.shoppingmall.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,5 +25,10 @@ public class OrderController {
     @PostMapping("/create")
     public ResponseEntity<Response> createOrder(@RequestBody OrderRequest orderRequest) {
         return ResponseEntity.ok(orderService.createOrder(orderRequest));
+    }
+
+    @GetMapping("/change-status")
+    public ResponseEntity<Response> changeStatus(@RequestBody OrderRequest orderRequest) {
+        return ResponseEntity.ok(orderService.changeOrderStatus(orderRequest));
     }
 }

--- a/src/main/java/com/bit/joe/shoppingmall/dto/request/OrderRequest.java
+++ b/src/main/java/com/bit/joe/shoppingmall/dto/request/OrderRequest.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.bit.joe.shoppingmall.enums.OrderStatus;
+
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/bit/joe/shoppingmall/dto/request/OrderRequest.java
+++ b/src/main/java/com/bit/joe/shoppingmall/dto/request/OrderRequest.java
@@ -3,6 +3,7 @@ package com.bit.joe.shoppingmall.dto.request;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.bit.joe.shoppingmall.enums.OrderStatus;
 import lombok.Builder;
 import lombok.Data;
 
@@ -10,7 +11,9 @@ import lombok.Data;
 @Builder
 public class OrderRequest {
 
+    private Long orderId;
     private Long userId;
     private List<Long> cartItemIds;
     private LocalDateTime orderDate;
+    private OrderStatus status;
 }

--- a/src/main/java/com/bit/joe/shoppingmall/enums/OrderStatus.java
+++ b/src/main/java/com/bit/joe/shoppingmall/enums/OrderStatus.java
@@ -9,4 +9,6 @@ public enum OrderStatus {
     RETURN_REQUESTED,
     RETURN_IN_PROGRESS,
     RETURNED,
+    CANCEL_REQUESTED,
+    CANCELLED
 }

--- a/src/main/java/com/bit/joe/shoppingmall/service/Impl/OrderService.java
+++ b/src/main/java/com/bit/joe/shoppingmall/service/Impl/OrderService.java
@@ -107,4 +107,47 @@ public class OrderService {
         return Response.builder().status(200).message("Order status changed").build();
         // return success message
     }
+
+    public Response requestCancel(OrderRequest orderRequest) {
+        Order order =
+                orderRepository
+                        .findById(orderRequest.getOrderId())
+                        .orElseThrow(() -> new NotFoundException("Order not " + "found"));
+        // get order object
+
+        // if order status is over PREPARE status, return error message
+        if (order.getStatus().ordinal() > OrderStatus.PREPARE.ordinal()) {
+            return Response.builder().status(400).message("Order cannot be cancelled").build();
+        }
+
+        orderRequest.setStatus(OrderStatus.CANCEL_REQUESTED);
+        changeOrderStatus(orderRequest);
+        // change order status
+
+        return Response.builder().status(200).message("Order cancel requested").build();
+        // return success message
+    }
+
+    public Response confirmCancel(OrderRequest orderRequest) {
+        Order order =
+                orderRepository
+                        .findById(orderRequest.getOrderId())
+                        .orElseThrow(() -> new NotFoundException("Order not " + "found"));
+        // get order object
+
+        // if order status is not CANCEL_REQUESTED, return error message
+        if (order.getStatus() != OrderStatus.CANCEL_REQUESTED) {
+            return Response.builder()
+                    .status(400)
+                    .message("Order cannot be cancelled without cancel request.")
+                    .build();
+        }
+
+        orderRequest.setStatus(OrderStatus.CANCELLED);
+        changeOrderStatus(orderRequest);
+        // change order status
+
+        return Response.builder().status(200).message("Order cancelled").build();
+        // return success message
+    }
 }

--- a/src/main/java/com/bit/joe/shoppingmall/service/Impl/OrderService.java
+++ b/src/main/java/com/bit/joe/shoppingmall/service/Impl/OrderService.java
@@ -2,6 +2,7 @@ package com.bit.joe.shoppingmall.service.Impl;
 
 import java.util.List;
 
+import com.bit.joe.shoppingmall.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 
 import com.bit.joe.shoppingmall.dto.request.OrderRequest;
@@ -86,6 +87,22 @@ public class OrderService {
         // save order items
 
         return Response.builder().message("Order created successfully").build();
+        // return success message
+    }
+
+    public Response changeOrderStatus(OrderRequest orderRequest) {
+
+        Order order = orderRepository.findById(orderRequest.getOrderId())
+                .orElseThrow(() -> new NotFoundException("Order not found"));
+        // get order object
+
+        order.setStatus(orderRequest.getStatus());
+        // change order status
+
+        orderRepository.save(order);
+        // save order object
+
+        return Response.builder().status(200).message("Order status changed").build();
         // return success message
     }
 }

--- a/src/main/java/com/bit/joe/shoppingmall/service/Impl/OrderService.java
+++ b/src/main/java/com/bit/joe/shoppingmall/service/Impl/OrderService.java
@@ -2,7 +2,6 @@ package com.bit.joe.shoppingmall.service.Impl;
 
 import java.util.List;
 
-import com.bit.joe.shoppingmall.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 
 import com.bit.joe.shoppingmall.dto.request.OrderRequest;
@@ -11,6 +10,7 @@ import com.bit.joe.shoppingmall.entity.CartItem;
 import com.bit.joe.shoppingmall.entity.Order;
 import com.bit.joe.shoppingmall.entity.OrderItem;
 import com.bit.joe.shoppingmall.enums.OrderStatus;
+import com.bit.joe.shoppingmall.exception.NotFoundException;
 import com.bit.joe.shoppingmall.mapper.OrderItemMapper;
 import com.bit.joe.shoppingmall.repository.CartItemRepository;
 import com.bit.joe.shoppingmall.repository.OrderItemRepository;
@@ -92,8 +92,10 @@ public class OrderService {
 
     public Response changeOrderStatus(OrderRequest orderRequest) {
 
-        Order order = orderRepository.findById(orderRequest.getOrderId())
-                .orElseThrow(() -> new NotFoundException("Order not found"));
+        Order order =
+                orderRepository
+                        .findById(orderRequest.getOrderId())
+                        .orElseThrow(() -> new NotFoundException("Order not found"));
         // get order object
 
         order.setStatus(orderRequest.getStatus());


### PR DESCRIPTION
# 설명

- [feat: /api/order/change-status](https://github.com/fish895623/joe_shop/commit/8afb70963cb2b9c9993c2838060330774c9b52e0)

- [feat : /api/order/request-cancel , /api/order/confirm-cancel](https://github.com/fish895623/joe_shop/commit/acfdbe6cd990817838ff21566a6fb8fcbc3ee5b4) 


## 변경 타입

- 기능 추가

## 테스트 방법

- DATA SOURCE 변경
	- 
![image](https://github.com/user-attachments/assets/d317ac07-a1ac-4af7-9a08-b4ec7053bfac)
- 기본적으로 order_status(주문 상태)가 DELIVER 이전이어야 취소 요청이 가능
- 취소 요청된 주문만 취소 확인(confirm_cancel)이 가능

## Checklist:

- [x] 코드 스타일 ./gradlew spotlessApply 를 적용하였습니다.
- [x] 올리기 전에 코드 리뷰 작업을 하였습니다.
- [x] 어려운 부분에 대해 주석을 추가했습니다
- [x] 문서에 해당 변경 사항을 반영했습니다
- [x] 변경 사항으로 인한 치명적인 경고가 없습니다
